### PR TITLE
Pengfei/generating automatic msl binding json

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -708,6 +708,7 @@ struct CLIArguments
 	SmallVector<BuiltIn> masked_stage_builtins;
 	string entry;
 	string entry_stage;
+	string msl_binding_output;
 
 	struct Rename
 	{
@@ -1542,9 +1543,8 @@ static string compile_iteration(const CLIArguments &args, std::vector<uint32_t> 
 		auto compilerMSL = static_cast<CompilerMSL *>(compiler.get());
 		auto resources = compilerMSL->get_shader_resources();
 
-		std::string msl_binding_map_json_file_name(args.input);
-		msl_binding_map_json_file_name += ".json";
-		std::ofstream msl_binding_map(msl_binding_map_json_file_name);
+		std::string msl_binding_map_output_file_name(args.msl_binding_output);
+		std::ofstream msl_binding_map(msl_binding_map_output_file_name);
 
 		msl_binding_map << "{" << std::endl;
 		msl_binding_map << "  \"textures\": [" << std::endl;
@@ -1625,10 +1625,10 @@ static string compile_iteration(const CLIArguments &args, std::vector<uint32_t> 
 				msl_binding_map << ",";
 			}
 			msl_binding_map << std::endl;
+			i++;
 		}
 		msl_binding_map << "  ]" << std::endl;
 		msl_binding_map << "}" << std::endl;
-		i++;
 	}
 
 	if (args.dump_resources)
@@ -1880,6 +1880,8 @@ static int main_inner(int argc, char *argv[])
 	cbs.add("--msl-combined-sampler-suffix", [&args](CLIParser &parser) {
 		args.msl_combined_sampler_suffix = parser.next_string();
 	});
+	cbs.add("--msl-binding-output",
+	        [&args](CLIParser &parser) { args.msl_binding_output = parser.next_string(); });
 	cbs.add("--extension", [&args](CLIParser &parser) { args.extensions.push_back(parser.next_string()); });
 	cbs.add("--rename-entry-point", [&args](CLIParser &parser) {
 		auto old_name = parser.next_string();

--- a/main.cpp
+++ b/main.cpp
@@ -1546,88 +1546,46 @@ static string compile_iteration(const CLIArguments &args, std::vector<uint32_t> 
 		std::string msl_binding_map_output_file_name(args.msl_binding_output);
 		std::ofstream msl_binding_map(msl_binding_map_output_file_name);
 
+		auto output_msl_bindings_as_json = [&compilerMSL, &msl_binding_map](const SmallVector<Resource> &resources)
+		{
+			size_t size = resources.size();
+			size_t i = 0;
+			for (auto &resource : resources)
+			{
+				int32_t msl_binding = compilerMSL->get_automatic_msl_resource_binding(resource.id);
+				int32_t binding = compilerMSL->get_decoration(resource.id, spv::DecorationBinding);
+				msl_binding_map << "    {" << std::endl;
+				msl_binding_map << "    \"binding\":" << binding << "," << std::endl;
+				msl_binding_map << "    \"msl_binding\":" << msl_binding << std::endl;
+				msl_binding_map << "    }";
+				if (i < (size - 1))
+				{
+					msl_binding_map << ",";
+				}
+				msl_binding_map << std::endl;
+				i++;
+			}
+		};
 		msl_binding_map << "{" << std::endl;
+
 		msl_binding_map << "  \"textures\": [" << std::endl;
-
-		size_t size = resources.sampled_images.size();
-		size_t i = 0;
-		for (auto &sampler_image : resources.sampled_images)
-		{
-			uint32_t msl_binding = compilerMSL->get_automatic_msl_resource_binding(sampler_image.id);
-			uint32_t binding = compilerMSL->get_decoration(sampler_image.id, spv::DecorationBinding);
-			msl_binding_map << "    {" << std::endl;
-			msl_binding_map << "    \"binding\":" << binding << "," << std::endl;
-			msl_binding_map << "    \"msl_binding\":" << msl_binding << std::endl;
-			msl_binding_map << "    }";
-			if (i < (size - 1))
-			{
-				msl_binding_map << ",";
-			}
-			msl_binding_map << std::endl;
-			i++;
-		}
-
+		output_msl_bindings_as_json(resources.sampled_images);
 		msl_binding_map << "  ]," << std::endl;
+
+
 		msl_binding_map << "  \"images\": [" << std::endl;
-
-		size = resources.storage_images.size();
-		i = 0;
-		for (auto &storage_image : resources.storage_images)
-		{
-			uint32_t msl_binding = compilerMSL->get_automatic_msl_resource_binding(storage_image.id);
-			uint32_t binding = compilerMSL->get_decoration(storage_image.id, spv::DecorationBinding);
-			msl_binding_map << "    {" << std::endl;
-			msl_binding_map << "    \"binding\":" << binding << "," << std::endl;
-			msl_binding_map << "    \"msl_binding\":" << msl_binding << std::endl;
-			msl_binding_map << "    }";
-			if (i < (size - 1))
-			{
-				msl_binding_map << ",";
-			}
-			msl_binding_map << std::endl;
-			i++;
-		}
-
+		output_msl_bindings_as_json(resources.storage_images);
 		msl_binding_map << "  ]," << std::endl;
+
 		msl_binding_map << "  \"ubos\": [" << std::endl;
-		size = resources.uniform_buffers.size();
-		i = 0;
-		for (auto &uniform_buffer : resources.uniform_buffers)
-		{
-			uint32_t msl_binding = compilerMSL->get_automatic_msl_resource_binding(uniform_buffer.id);
-			uint32_t binding = compilerMSL->get_decoration(uniform_buffer.id, spv::DecorationBinding);
-			msl_binding_map << "    {" << std::endl;
-			msl_binding_map << "    \"binding\":" << binding << "," << std::endl;
-			msl_binding_map << "    \"msl_binding\":" << msl_binding << std::endl;
-			msl_binding_map << "    }";
-			if (i < (size - 1))
-			{
-				msl_binding_map << ",";
-			}
-			msl_binding_map << std::endl;
-			i++;
-		}
-
+		output_msl_bindings_as_json(resources.uniform_buffers);
 		msl_binding_map << "  ]," << std::endl;
+
+
 		msl_binding_map << "  \"ssbos\": [" << std::endl;
-		size = resources.storage_buffers.size();
-		i = 0;
-		for (auto &storage_buffer : resources.storage_buffers)
-		{
-			uint32_t msl_binding = compilerMSL->get_automatic_msl_resource_binding(storage_buffer.id);
-			uint32_t binding = compilerMSL->get_decoration(storage_buffer.id, spv::DecorationBinding);
-			msl_binding_map << "    {" << std::endl;
-			msl_binding_map << "    \"binding\":" << binding << "," << std::endl;
-			msl_binding_map << "    \"msl_binding\":" << msl_binding << std::endl;
-			msl_binding_map << "    }";
-			if (i < (size - 1))
-			{
-				msl_binding_map << ",";
-			}
-			msl_binding_map << std::endl;
-			i++;
-		}
+		output_msl_bindings_as_json(resources.storage_buffers);
 		msl_binding_map << "  ]" << std::endl;
+
 		msl_binding_map << "}" << std::endl;
 	}
 


### PR DESCRIPTION

As title says

The branch changes the spirv tool to output the binding slot mapping between GLSL and MSL.

the output looks like as below:
```
{
  "textures": [
    {
    "binding":1,
    "msl_binding":0
    },
    {
    "binding":2,
    "msl_binding":1
    }
  ],
  "images": [
    {
    "binding":0,
    "msl_binding":2
    }
  ],
  "ubos": [
    {
    "binding":1,
    "msl_binding":0
    },
    {
    "binding":0,
    "msl_binding":2
    }
  ],
  "ssbos": [
    {
    "binding":3,
    "msl_binding":1
    }
  ]
}

```

